### PR TITLE
Fix usage of magnitude for kilobyte output

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,11 @@
         spec = spec || {};
         
         var algorithm = spec.si ? ['k', 'B'] : ['K', 'iB']
-          , input = sizable.calculate(spec.si);
+          , input = sizable.calculate(spec.si)
+          , magnitudeIndex = input.magnitude - 1;
 
-        if (--input.magnitude < 2 && !spec.si && spec.jedec) algorithm[1] = 'B';
-        return input.fixed + options.spacer + (input.magnitude ? (algorithm[0] + 'MGTPEZY')[input.magnitude] + algorithm[1] : 'Bytes');
+        if (magnitudeIndex < 2 && !spec.si && spec.jedec) algorithm[1] = 'B';
+        return input.fixed + options.spacer + (input.magnitude ? (algorithm[0] + 'MGTPEZY')[magnitudeIndex] + algorithm[1] : 'Bytes');
       }
     };
 


### PR DESCRIPTION
KB sizes would never be shown by the human function because the input magnitude was getting decreased, and this would then interfere with it's usage on the ternary condition that would decide whether to show a prefix or just show Bytes.
